### PR TITLE
Add cacert to build inputs

### DIFF
--- a/annepro2-tools.nix
+++ b/annepro2-tools.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ autoPatchelfHook ];
 
-  buildInputs = [ pkgs.libusb1 pkgs.cargo pkgs.rustc pkgs.pkgconfig];
+  buildInputs = [ pkgs.cacert pkgs.libusb1 pkgs.cargo pkgs.rustc pkgs.pkgconfig ];
 
   installPhase = ./annepro2-tools-install.sh;
   system = builtins.currentSystem;


### PR DESCRIPTION
Without this, i'm encountering

```
vitalya@celebi ~> nix shell github:headblockhead/nix-annepro2-tools --no-sandbox                                
error: builder for '/nix/store/zy54pz2k2flwzwdpmdb48vh5w3bg8sv7-annepro2-tools-fe5ed6585b0af274e3220d5abe49ee419c34924a.drv' failed with exit code 1;
       last 10 log lines:
       > Caused by:
       >   download of config.json failed
       >
       > Caused by:
       >   failed to download from `https://index.crates.io/config.json`
       >
       > Caused by:
       >   [60] SSL peer certificate or SSH remote key was not OK (SSL certificate problem: unable to get local issuer certificate)
       > cp: cannot stat './target/release/annepro2_tools': No such file or directory
       > chmod: cannot access '/nix/store/025k8wvilgw5wrc1h96wi05zwaf3p52v-annepro2-tools-fe5ed6585b0af274e3220d5abe49ee419c34924a/bin/annepro2-tools': No such file or directory
       For full logs, run 'nix log /nix/store/zy54pz2k2flwzwdpmdb48vh5w3bg8sv7-annepro2-tools-fe5ed6585b0af274e3220d5abe49ee419c34924a.drv'.
```